### PR TITLE
simpler and WCAG wording

### DIFF
--- a/script8.html
+++ b/script8.html
@@ -76,7 +76,7 @@
       <th scope="row">7</th>
       <td>0:08</td>
       <td>0:34</td>
-      <td>Good design allows anyone to resize or recolor text without loss of formatting function or clarity.</td>
+      <td>Good design allows anyone to change the way text is displayed without loss of content or functionality.</td>
       <td>&lt;&lt;&lt;These words now appear on the screen of a tablet being used by someone in the cafe</td>
       <td></td>
     </tr>


### PR DESCRIPTION
"... without loss of formatting function or clarity."  ... huh?
-> "... without loss of content or functionality."
Matches WCAG wording exactly and seems more correct and simpler.

"...to resize or recolor text...."
-> "...to change the way text is displayed..."

Text customization is about much more than resizing or recoloring text (see http://w3c.github.io/low-vision-a11y-tf/requirements.html#user-needs ). I know the video only covers a few points for focus -- but it's good to say "for example" or "etc" to help indicate there are more. And then in the concluding statements like this, make it broader.
