### PR TITLE
not color contrast

### DIFF
--- a/script2.html
+++ b/script2.html
@@ -7,7 +7,7 @@
   <link href="http://www.w3.org/WAI/wai-main.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
-<h1>Script 2: Color Contrast</h1>
+<h1>Script 2: (Color) Contrast Ratio</h1>
 <p><a href="Overview.html">&lt; Scripts for Showcase Examples with Videos</a></p>
 
 <p>Relate the issue to the personal experience of the reader/viewer, as most will have encountered a situation of illegible text. Emphasize that good choice of colors is good practice in addition to an accessibility requirement. Use the statistic "1 in 12 adult males" and age-related visual limitations to counter the myth that it is only about a small group of people impacted. Explain the additional benefits, especially for mobile use.</p>
@@ -36,7 +36,7 @@
       <th scope="row">2</th>
       <td>0:07</td>
       <td>0:11</td>
-      <td>But it doesn’t take much to make this a confusing and frustrating mess. Poor color contrast makes navigating a real pain</td>
+      <td>But it doesn’t take much to make it frustrating. Poor  contrast can make navigating and reading difficult or impossible</td>
       <td>Same scene, but with the road signs changed so there’s almost no contrast (probably digitally) this time the person looks confused and has to walk right up to the signs to try to figure them out. Person leans over, points to a sign with a confused face and asks another person what the sign says.</td>
       <td></td>
     </tr>
@@ -44,7 +44,7 @@
       <th scope="row">3</th>
       <td>0:05</td>
       <td>0:16</td>
-      <td>Good design means sufficient contrast between foreground and background.</td>
+      <td>Good design means sufficient contrast between foreground and background colors.</td>
       <td>Cut to a person in the street looking at their phone’s navigation app. They look confused.</td>
       <td></td>
     </tr>
@@ -52,7 +52,7 @@
       <th scope="row">4</th>
       <td>0:07</td>
       <td>0:18</td>
-      <td>That’s not just text and images but links, icons, and buttons – if it’s important enough to be seen then it needs to be clear!</td>
+      <td>That’s not just text and images but links, icons, and buttons – if it’s important enough to be seen then it needs to be visible!</td>
       <td>The person using the app looks at a poorly contrasted button that becomes clear as they look at it.</td>
       <td></td>
     </tr>
@@ -62,7 +62,7 @@
       <td>0:32</td>
       <td>And this can be especially problematic for people with color perception limitations – to someone with this condition, this, can look like this!<br>
 				Approximately 1 in 12 adult males have this condition – that’s a lot of people.</td>
-      <td>Show the wider scene of the person on their sofa looking at the tablet, then apply color filters to it so that they themselves blend into the sofa – they look taken aback by what’s happened.</td>
+      <td>Show the wider scene of the person on their sofa looking at the tablet, then apply dullness filters to it so that they themselves blend into the sofa – they look taken aback by what’s happened.</td>
       <td></td>
     </tr>
     <tr>
@@ -77,7 +77,7 @@
       <th scope="row">7</th>
       <td>0:04</td>
       <td>0:39</td>
-      <td>With good colors websites and applications can be easier to use in more situations</td>
+      <td>With good contrast, websites and applications can be easier to use in more situations</td>
       <td>Person puts tablet down and looks at same site on phone</td>
       <td></td>
     </tr>
@@ -85,7 +85,7 @@
       <th scope="row">8</th>
       <td>0:03</td>
       <td>0:42</td>
-      <td>Like when the lighting conditions change</td>
+      <td>Like in different lighting conditions</td>
       <td>The lighting conditions change -  sun glares on to the phone screen – but it’s still clear as a bell</td>
       <td></td>
     </tr>
@@ -93,7 +93,7 @@
       <th scope="row">9</th>
       <td>0:11</td>
       <td>0:53</td>
-      <td>If there’s sufficient color contrast more people can make use of the content in more environments – it’s just common sense<br>
+      <td>If there’s sufficient  contrast more people can make use of the content in more environments – it’s just common sense<br>
 				visit w3.org/WAI for more tips and information</td>
       <td>We see the person from earlier in the film walking the streets, navigating using their mobile phone. They arrive at their destination</td>
       <td></td>


### PR DESCRIPTION
"(This accessibility requirement is sometimes called sufficient "color contrast"; however, that is incorrect — technically it's "luminance contrast". On this page we use "contrast ratio" as short for "luminance contrast ratio" because it's less jargony.)" - https://www.w3.org/WAI/eval/preliminary.html#contrast
