### PR TITLE
[controls] minor copyedit - for ed's discretion

### DIFF
--- a/controls.html
+++ b/controls.html
@@ -126,7 +126,7 @@
       <p>[ <a href="speech.html"><strong>Previous:</strong> Text to Speech</a> | <a href="Overview.html">Up: Overview</a> | <a href="captions.html"><strong>Next:</strong> Video Captions</a> ]</p>
 
       <h2 id="what">What is Large Links, Buttons, and Controls?</h2>
-      <p>The area for clicking and tapping controls should be large enough for people to activate them. This includes links, buttons, checkboxes, and other controls. Small controls, or controls that are placed too close to each other, are difficult for many people to use. This is particularly relevant on mobile devices with small screens.</p>
+      <p>The area for clicking and tapping controls should be large enough for people to activate them. This includes links, buttons, checkboxes, and other controls. Small controls, and controls that are placed too close to each other, are difficult for many people to use. This is particularly relevant on mobile devices with small screens.</p>
 
       <h2 id="who">Who depends on this feature?</h2>
       <ul>


### PR DESCRIPTION
I'm not sure about the commas. Some might argue they don't below there and it should just be:

> Small controls and controls that are placed too close to each other are difficult for many people to use.
> However, I think the commas help group the info, so I lean toward leaving them...
